### PR TITLE
Add disable tests cmake option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ CTestTestfile.cmake
 _deps
 cmake-build-debug
 cmake-build-release
+Debug
+Release
+

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 *.geany
 
 .idea/
+.cache/
 
 CMakeLists.txt.user
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,16 @@ project(avrcpp VERSION 1.1.0)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 11) # 20 is a cmake 3.21+ feature
 message("${CMAKE_PROJECT_NAME} version ${CMAKE_PROJECT_VERSION}")
+option(DISABLE_TESTS "Disable inclusion of the unit tests (useful if you dont want to depend on GTEST)" OFF)
 
-add_library(avrcpp
-        src/utillities.cpp
-)
+add_library(avrcpp src/utillities.cpp)
 
 # This is only used internally to make my clangd-tidy happy. Dont link to this
 add_library(__avrcpp_is src/avrcpp_includer.cpp)
 target_compile_options(__avrcpp_is PUBLIC -nodefaultlibs)
 target_link_libraries(__avrcpp_is avrcpp)
 
-add_subdirectory( test )
+if(NOT DISABLE_TESTS)
+        add_subdirectory( test )
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
-project(avrcpp VERSION 1.1.0)
+project(avrcpp VERSION 1.1.1)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 11) # 20 is a cmake 3.21+ feature
 message("${CMAKE_PROJECT_NAME} version ${CMAKE_PROJECT_VERSION}")

--- a/include/stl/unique_ptr.h
+++ b/include/stl/unique_ptr.h
@@ -18,7 +18,7 @@
 #ifndef UNIQUE_PTR_HPP
 #define UNIQUE_PTR_HPP
 #include "default_deleters.h"
-#include "utility"
+#include "../utility"
 
 namespace stl {
     /// Unique pointer class. Pointer with unique ownership of

--- a/include/stl/vector.h
+++ b/include/stl/vector.h
@@ -176,7 +176,7 @@ namespace stl {
     template<class T>
     void vector<T>::erase(iterator pos) {
         for(auto i = pos; i + 1 != end(); ++i)
-            *i = *(i + 1);
+            *i = stl::move(*(i + 1));
         pop_back();
     }
 

--- a/include/stl/vector.h
+++ b/include/stl/vector.h
@@ -46,6 +46,7 @@ namespace stl {
         void push_back(const T& value);
         void emplace_back(T&& value);
         void erase(iterator pos);
+        void erase_index(unsigned int index);
         void insert(iterator pos, const T& value);
         void pop_back();
         void reserve(unsigned int new_cap);
@@ -176,8 +177,19 @@ namespace stl {
     template<class T>
     void vector<T>::erase(iterator pos) {
         for(auto i = pos; i + 1 != end(); ++i)
-            *i = stl::move(*(i + 1));
+            *i = *(i + 1);
         pop_back();
+    }
+
+    template<class T>
+    void vector<T>::erase_index(unsigned int index) {
+        if(index == size()-1)
+            pop_back();
+        else if(index < size()-1) {
+            for(auto i = index; i + 1 != size(); ++i)
+                data[i] = data[i+1];
+            pop_back();
+        }
     }
 
     template<typename T>


### PR DESCRIPTION
This enables users to include the project, but ignore the tests and subsequently ignore the transient GTest dependency.